### PR TITLE
Fix inling of computeE function.

### DIFF
--- a/simple-gotracing/app/app.go
+++ b/simple-gotracing/app/app.go
@@ -25,6 +25,7 @@ import (
 )
 
 // computeE computes the approximation of e by running a fixed number of iterations.
+//go:noinline
 func computeE(iterations int64) float64 {
 	res := 2.0
 	fact := 1.0


### PR DESCRIPTION
Tested with nm: `nm app | grep computeE` now produces a result for `go1.16 darwin/amd64`.