### PR TITLE
Updated SQL injection demo to have slackbot, added pointers to demo video

### DIFF
--- a/custom-k8s-metrics-demo/README.md
+++ b/custom-k8s-metrics-demo/README.md
@@ -8,6 +8,8 @@ This demo provides an example implementation of a custom Kubernetes metric from 
 
 This demo was based off of the example in [kubernetes-sigs/custom-metrics-apiserver](https://github.com/kubernetes-sigs/custom-metrics-apiserver).
 
+You can also view a live version of this demo at this [talk](https://www.youtube.com/watch?v=EG4isSqD3IE) (autoscaling content at about 22:43 in).
+
 ## Prerequisites
 
 * If you don't already have one, set up a [Kubernetes cluster](https://docs.px.dev/installing-pixie/setting-up-k8s/)

--- a/sql-injection-demo/README.md
+++ b/sql-injection-demo/README.md
@@ -153,13 +153,11 @@ the bottom of the CLI output at `Live UI:`.
 
 1. cd into the `slackbot` directory
 
-1. `pip install -r requirements.txt`
+2. `pip install -r requirements.txt`
 
-1. Set the environment variables `PIXIE_API_KEY`, `SLACK_BOT_TOKEN`, `PIXIE_CLUSTER_ID`, and `SLACK_ALERT_CHANNEL`. 
+3. Set the environment variables `PIXIE_API_KEY`, `SLACK_BOT_TOKEN`, `PIXIE_CLUSTER_ID`, and `SLACK_ALERT_CHANNEL`. You can reference [these instructions](https://docs.px.dev/tutorials/integrations/slackbot-alert/) for how to get `PIXIE_API_KEY`, `SLACK_BOT_TOKEN`, and `PIXIE_CLUSTER_ID`.
 
-You can reference [these instructions](https://docs.px.dev/tutorials/integrations/slackbot-alert/) for how to get `PIXIE_API_KEY`, `SLACK_BOT_TOKEN`, and `PIXIE_CLUSTER_ID`.
-
-2. Run the following command. Note: this requires Python `3.8.7` or greater.
+4. Run the following command. Note: this requires Python `3.8.7` or greater.
 
     ```
     python slackboy.py

--- a/sql-injection-demo/README.md
+++ b/sql-injection-demo/README.md
@@ -8,6 +8,8 @@ to SQL injection monitored by Pixie, run
 application, and detect the SQL injections at the database level using a PxL script.
 This demo was created to accompany the "Detect SQL injections with Pixie" [blog post](https://blog.px.dev/sql-injection/).
 
+You can also view a live version of this demo at this [talk](https://www.youtube.com/watch?v=EG4isSqD3IE) (SQL injection content at about 11:51 in).
+
 ## WARNING
 
 DVWA is an *intentionally* vulnerable web application. It should **NOT** be deployed to
@@ -146,6 +148,22 @@ the bottom of the CLI output at `Live UI:`.
 1. Replace the Vis Spec tab contents with the contents of `script/vis.json`.
 1. Click Run.
 1. You should now see the SQL Injection queries run by SQLMap in the data table.
+
+## (Optional) Run Slackbot to alert on possible SQL injections
+
+1. cd into the `slackbot` directory
+
+1. `pip install -r requirements.txt`
+
+1. Set the environment variables `PIXIE_API_KEY`, `SLACK_BOT_TOKEN`, `PIXIE_CLUSTER_ID`, and `SLACK_ALERT_CHANNEL`. 
+
+You can reference [these instructions](https://docs.px.dev/tutorials/integrations/slackbot-alert/) for how to get `PIXIE_API_KEY`, `SLACK_BOT_TOKEN`, and `PIXIE_CLUSTER_ID`.
+
+2. Run the following command. Note: this requires Python `3.8.7` or greater.
+
+    ```
+    python slackboy.py
+    ```
 
 ## Clean up
 

--- a/sql-injection-demo/README.md
+++ b/sql-injection-demo/README.md
@@ -160,7 +160,7 @@ the bottom of the CLI output at `Live UI:`.
 4. Run the following command. Note: this requires Python `3.8.7` or greater.
 
     ```
-    python slackboy.py
+    python slackbot.py
     ```
 
 ## Clean up

--- a/sql-injection-demo/slackbot/requirements.txt
+++ b/sql-injection-demo/slackbot/requirements.txt
@@ -1,0 +1,4 @@
+pxapi==0.4.1
+schedule==0.6.0
+slack==0.0.2
+slackclient==2.9.3

--- a/sql-injection-demo/slackbot/slackbot.py
+++ b/sql-injection-demo/slackbot/slackbot.py
@@ -1,0 +1,114 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import logging
+import os
+import schedule
+import pxapi
+from slack.web.client import WebClient
+from slack.errors import SlackApiError
+
+
+logging.basicConfig(level=logging.INFO)
+
+# The slackbot requires the following configs, which are specified
+# using environment variables. For directions on how to find these
+# config values, see: https://docs.px.dev/tutorials/integrations/slackbot-alert/
+if "PIXIE_API_KEY" not in os.environ:
+    logging.error("Missing `PIXIE_API_KEY` environment variable.")
+pixie_api_key = os.environ['PIXIE_API_KEY']
+
+if "PIXIE_CLUSTER_ID" not in os.environ:
+    logging.error("Missing `PIXIE_CLUSTER_ID` environment variable.")
+pixie_cluster_id = os.environ['PIXIE_CLUSTER_ID']
+
+if "SLACK_BOT_TOKEN" not in os.environ:
+    logging.error("Missing `SLACK_BOT_TOKEN` environment variable.")
+slack_bot_token = os.environ['SLACK_BOT_TOKEN']
+
+# Slack channel for Slackbot to post in.
+# Slack App must be a member of this channel.
+if "SLACK_ALERT_CHANNEL" not in os.environ:
+    logging.error("Missing `SLACK_ALERT_CHANNEL` environment variable.")
+slack_channel = os.environ['SLACK_ALERT_CHANNEL']
+
+pxl_script = open("sql_injections.pxl", "r").read()
+
+def get_pixie_data(cluster_conn):
+    msg = ["*Possible SQL injections detected in last 30 seconds*"]
+
+    script = cluster_conn.prepare_script(pxl_script)
+
+    # If you change the PxL script, you'll need to change the
+    # columns this script looks for in the result table.
+    for row in script.results("possible_sql_injections"):
+        msg.append(format_message(row["rule_broken"],
+                                  row["source"],
+                                  row["req_body"]))
+
+    if len(msg) == 1:
+        return "*No SQL injections detected in last 30 seconds*"
+
+    return "\n\n".join(msg)
+
+
+def format_message(rule_broken, source, req_body):
+    return (f"Rule `{rule_broken}` violated on `{source}`\n" +
+        f"SQL: `{req_body}`")
+
+
+def send_slack_message(slack_client, channel, cluster_conn):
+
+    # Get data from the Pixie API.
+    msg = get_pixie_data(cluster_conn)
+
+    # Send a POST request through the Slack client.
+    try:
+        logging.info(f"Sending {msg!r} to {channel!r}")
+        slack_client.chat_postMessage(channel=channel, text=msg)
+
+    except SlackApiError as e:
+        logging.error('Request to Slack API Failed: {}.'.format(e.response.status_code))
+        logging.error(e.response)
+
+
+def main():
+
+    logging.debug("Authorizing Pixie client.")
+    px_client = pxapi.Client(token=pixie_api_key)
+
+    cluster_conn = px_client.connect_to_cluster(pixie_cluster_id)
+    logging.debug("Pixie client connected to %s cluster.", cluster_conn.name())
+
+    logging.debug("Authorizing Slack client.")
+    slack_client = WebClient(slack_bot_token)
+
+    # Send the first message right when we start up.
+    send_slack_message(slack_client, slack_channel, cluster_conn)    
+
+    # Schedule sending a Slack channel message every 30 seconds.
+    schedule.every(30).seconds.do(lambda: send_slack_message(slack_client,
+                                                            slack_channel,
+                                                            cluster_conn))
+
+    logging.info("Message scheduled for %s Slack channel.", slack_channel)
+
+    while True:
+        schedule.run_pending()
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    main()

--- a/sql-injection-demo/slackbot/sql_injections.pxl
+++ b/sql-injection-demo/slackbot/sql_injections.pxl
@@ -1,0 +1,111 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+''' PostgreSQL Data Tracer
+Shows the most recent PostgreSQL messages in the cluster.
+'''
+
+# This is the same as `script/sql_injections.pxl`, but it addx px.display at the
+# end of the script. (so that it can be used in the Pixie client API, which doesn't
+# yet support vis.json files). It also removes the deep links so that the output
+# is a bit more friendly to Slack.
+
+import px
+SCRIPT_TAG_RULE = "(<|%3C)\s*[sS][cC][rR][iI][pP][tT]"
+COMMENT_DASH_RULE = "--"
+COMMENT_HASHTAG_RULE = "#"
+COMMENT_SLASH_RULE = "\/\*"
+SEMICOLON_RULE = ";.+"
+UNMATCHED_SINGLE_QUOTES_RULE = "^([^']*'([^']*'[^']*')*[^']*')[^']*'[^']*$"
+UNMATCHED_DOUBLE_QUOTES_RULE = '^([^"]*"([^"]*"[^"]*")*[^"]*")[^"]*"[^"]*$'
+UNION_RULE = "UNION"
+CHAR_CASTING_RULE = "[cC][hH][rR](\(|%28)"
+SYSTEM_CATALOG_ACCESS_RULE = "[fF][rR][oO][mM]\s+[mM][yY][sS][qQ][lL]"
+# google re2 doesn't support backreferences
+# ALWAYS_TRUE_RULE = "OR\s+(['\w]+)=\1"
+def add_sql_injection_rule(df, rule_name, rule):
+    df[rule_name] = px.regex_match(".*" + rule + ".*", df.req_body)
+    return df
+def sql_injections(df):
+    df = add_sql_injection_rule(df, 'script_tag', SCRIPT_TAG_RULE)
+    df = add_sql_injection_rule(df, 'comment_dashes', COMMENT_DASH_RULE)
+    df = add_sql_injection_rule(df, 'comment_hashtag', COMMENT_HASHTAG_RULE)
+    df = add_sql_injection_rule(df, 'comment_slash_star', COMMENT_SLASH_RULE)
+    df = add_sql_injection_rule(df, 'semicolon', SEMICOLON_RULE)
+    df = add_sql_injection_rule(df, 'unmatched_single_quotes', UNMATCHED_SINGLE_QUOTES_RULE)
+    df = add_sql_injection_rule(df, 'unmatched_double_quotes', UNMATCHED_DOUBLE_QUOTES_RULE)
+    df = add_sql_injection_rule(df, 'union', UNION_RULE)
+    df = add_sql_injection_rule(df, 'char_casting', CHAR_CASTING_RULE)
+    df = add_sql_injection_rule(df, 'system_catalog_access', SYSTEM_CATALOG_ACCESS_RULE)
+    df = df[
+        df.script_tag or (df.comment_dashes or ( df.comment_hashtag or (df.comment_slash_star or (df.semicolon or (
+                df.unmatched_single_quotes or ( df.unmatched_double_quotes or (df.union or (df.char_casting or df.system_catalog_access))))))))]
+    df.rule_broken = px.select(df.script_tag, 'script_tag',
+                        px.select(df.comment_dashes, 'comment_dashes',
+                            px.select(df.comment_hashtag, 'comment_hashtag',
+                                px.select(df.comment_slash_star, 'comment_slash_star',
+                                    px.select(df.unmatched_single_quotes, 'unmatched_single_quotes',
+                                        px.select(df.unmatched_double_quotes, 'unmatched_double_quotes',
+                                            px.select(df.union, 'union',
+                                                px.select(df.char_casting, 'char_casting',
+                                                    px.select(df.system_catalog_access,
+                                                        'system_catalog_access',
+                                                            px.select(df.semicolon,
+                                                                'semicolon',
+                                                                'N/A'))))))))))
+    return df[['time_', 'source', 'destination', 'remote_port', 'req_body', 'resp_body', 'latency', 'rule_broken']]
+def pgsql_data(start_time: str, source_filter: str, destination_filter: str, num_head: int):
+    df = px.DataFrame(table='mysql_events', start_time=start_time)
+    df = add_source_dest_columns(df)
+    # Filter out entities as specified by the user.
+    df = df[px.contains(df.source, source_filter)]
+    df = df[px.contains(df.destination, destination_filter)]
+    # Add additional filters below:
+    # Restrict number of results.
+    df = df.head(num_head)
+    df = df[['time_', 'source', 'destination', 'remote_port', 'req_body', 'resp_body', 'latency']]
+    return df
+def potential_sql_injections(start_time: str, source_filter: str, destination_filter: str, num_head: int):
+    df = pgsql_data(start_time, source_filter, destination_filter, num_head)
+    df = sql_injections(df)
+    return df
+def add_source_dest_columns(df):
+    ''' Add source and destination columns for the PostgreSQL request.
+    PostgreSQL requests are traced server-side (trace_role==2), unless the server is
+    outside of the cluster in which case the request is traced client-side (trace_role==1).
+    When trace_role==2, the PostgreSQL request source is the remote_addr column
+    and destination is the pod column. When trace_role==1, the PostgreSQL request
+    source is the pod column and the destination is the remote_addr column.
+    Input DataFrame must contain trace_role, upid, remote_addr columns.
+    '''
+    df.pod = df.ctx['pod']
+    df.namespace = df.ctx['namespace']
+    # If remote_addr is a pod, get its name. If not, use IP address.
+    df.ra_pod = px.pod_id_to_pod_name(px.ip_to_pod_id(df.remote_addr))
+    df.is_ra_pod = df.ra_pod != ''
+    df.ra_name = px.select(df.is_ra_pod, df.ra_pod, df.remote_addr)
+    df.is_server_tracing = df.trace_role == 2
+    df.is_source_pod_type = px.select(df.is_server_tracing, df.is_ra_pod, True)
+    df.is_dest_pod_type = px.select(df.is_server_tracing, True, df.is_ra_pod)
+    # Set source and destination based on trace_role.
+    df.source = px.select(df.is_server_tracing, df.ra_name, df.pod)
+    df.destination = px.select(df.is_server_tracing, df.pod, df.ra_name)
+    # Filter out messages with empty source / destination.
+    df = df[df.source != '']
+    df = df[df.destination != '']
+    df = df.drop(['ra_pod', 'is_ra_pod', 'ra_name', 'is_server_tracing'])
+    return df
+
+px.display(potential_sql_injections("-30s", "", "", 1000), "possible_sql_injections")


### PR DESCRIPTION
We have a SQL injection slackbot demo. Originally, I didn't check it in because it seemed too similar to the slackbot demo in this codebase. However, so that others can try it out and we can use it easily again in the future, I'm adding it to the sql-injection-demo directory.