### PR TITLE
Demo eBPF programs for portability blog

### DIFF
--- a/ebpf-portability/README.md
+++ b/ebpf-portability/README.md
@@ -1,0 +1,8 @@
+# eBPF Portability Demos
+
+This folder contains a basic eBPF probes to demonstrate portability issues.
+
+There are two folders in this demo:
+ - `basic`: A simple probe that counts the syscall of your choice, broken down per PID. This simple probe has no dependencies on Linux headers and is generally robust.
+ - `not_portable`: A variation of the basic probe that also considers the PID start time. This probe includes the Linux sched.h and would therefore be brittle if compiled with the wrong Linux headers.
+

--- a/ebpf-portability/basic/Makefile
+++ b/ebpf-portability/basic/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+tracer: tracer.cc
+	clang++ --std=c++17 -o $@ $^ -lbcc
+
+clean:
+	rm tracer

--- a/ebpf-portability/basic/probes.c
+++ b/ebpf-portability/basic/probes.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+// Map that stores counts of recv calls by PID
+BPF_HASH(counts_by_pid, uint32_t, int64_t);
+
+// Probe that counts every time it is triggered.
+// Can be used to count things like syscalls or particular functions.
+int syscall__probe_counter(struct pt_regs* ctx) {
+  uint32_t tgid = bpf_get_current_pid_tgid() >> 32;
+
+  int64_t kInitVal = 0;
+  int64_t* count = counts_by_pid.lookup_or_init(&tgid, &kInitVal);
+  if (count != NULL) {
+    *count = *count + 1;
+  }
+
+  return 0;
+}
+

--- a/ebpf-portability/basic/tracer.cc
+++ b/ebpf-portability/basic/tracer.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <fstream>
+#include <iostream>
+#include <streambuf>
+#include <string>
+
+#include <bcc/BPF.h>
+
+// Counts number of syscalls made by each PID for the specified run time.
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cout << "Usage: " << argv[0] << " <runtime> <syscall to count>" << std::endl;
+    std::cout << "Example: " << argv[0] << " 5 recvmsg" << std::endl;
+    exit(1);
+  }
+
+  int runtime = std::atoi(argv[1]);
+  std::string syscall(argv[2]);
+
+  // Read the BPF code.
+  std::ifstream ifs("probes.c");
+  std::string bpf_code(std::istreambuf_iterator<char>(ifs), {});
+
+  ebpf::BPF bcc;
+
+  bcc.init(std::string(bpf_code));
+
+  auto fnname = bcc.get_syscall_fnname(syscall);
+  bcc.attach_kprobe(fnname, "syscall__probe_counter");
+
+  sleep(runtime);
+
+  auto counts_by_pid = bcc.get_hash_table<uint32_t, int64_t>("counts_by_pid");
+
+  std::cout << "PID: count" << std::endl;
+  for (const auto& [pid, count] : counts_by_pid.get_table_offline()) {
+    std::cout << pid << ":\t" << count << std::endl;
+  }
+
+  return 0;
+}

--- a/ebpf-portability/not_portable/Makefile
+++ b/ebpf-portability/not_portable/Makefile
@@ -1,0 +1,21 @@
+# Copyright 2018- The Pixie Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+tracer: tracer.cc
+	clang++ --std=c++17 -o $@ $^ -lbcc
+
+clean:
+	rm tracer

--- a/ebpf-portability/not_portable/probes.c
+++ b/ebpf-portability/not_portable/probes.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <linux/sched.h>
+
+#include "types.h"
+
+// Effectively returns task->group_leader->real_start_time;
+// Note that before Linux 5.5, real_start_time was called start_boottime.
+static inline __attribute__((__always_inline__)) uint64_t get_tgid_start_time() {
+  struct task_struct* task = (struct task_struct*)bpf_get_current_task();
+  struct task_struct* group_leader_ptr = task->group_leader;
+  uint64_t start_time = group_leader_ptr->start_time;
+  return div_u64(start_time, NSEC_PER_SEC / USER_HZ);
+}
+
+// Map that stores counts of recv calls by PID
+BPF_HASH(counts_by_pid, struct tgid_ts_t, int64_t);
+
+// Probe that counts every time it is triggered.
+// Can be used to count things like syscalls or particular functions.
+int syscall__probe_counter(struct pt_regs* ctx) {
+  uint32_t tgid = bpf_get_current_pid_tgid() >> 32;
+  struct tgid_ts_t process_id = {};
+  process_id.tgid = tgid;
+  process_id.ts = get_tgid_start_time();
+
+  int64_t kInitVal = 0;
+  int64_t* count = counts_by_pid.lookup_or_init(&process_id, &kInitVal);
+  if (count != NULL) {
+    *count = *count + 1;
+  }
+
+  return 0;
+}
+

--- a/ebpf-portability/not_portable/tracer.cc
+++ b/ebpf-portability/not_portable/tracer.cc
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <fstream>
+#include <iostream>
+#include <streambuf>
+#include <string>
+
+#include <bcc/BPF.h>
+
+#include "types.h"
+
+// Counts number of syscalls made by each PID for the specified run time.
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cout << "Usage: " << argv[0] << " <runtime> <syscall to count>" << std::endl;
+    std::cout << "Example: " << argv[0] << " 5 recvmsg" << std::endl;
+    exit(1);
+  }
+
+  int runtime = std::atoi(argv[1]);
+  std::string syscall(argv[2]);
+
+  // Read the BPF code.
+  std::ifstream ifs("probes.c");
+  std::string bpf_code(std::istreambuf_iterator<char>(ifs), {});
+
+  ebpf::BPF bcc;
+
+  bcc.init(std::string(bpf_code));
+
+  auto fnname = bcc.get_syscall_fnname(syscall);
+  bcc.attach_kprobe(fnname, "syscall__probe_counter");
+
+  sleep(runtime);
+
+  auto counts_by_pid = bcc.get_hash_table<struct tgid_ts_t, int64_t>("counts_by_pid");
+
+  std::cout << "PID: count" << std::endl;
+  for (const auto& [pid, count] : counts_by_pid.get_table_offline()) {
+    std::cout << pid.tgid << "[start_time=" << pid.ts << "]:\t" << count << std::endl;
+  }
+
+  return 0;
+}

--- a/ebpf-portability/not_portable/types.h
+++ b/ebpf-portability/not_portable/types.h
@@ -1,0 +1,6 @@
+#pragma once
+
+struct tgid_ts_t {
+  uint32_t tgid;
+  uint64_t ts; // Timestamp when the process started.
+};


### PR DESCRIPTION
A couple of simple eBPF programs that serve as the reference for the eBPF portability blog.