### PR TITLE
[argo-rollouts-demo] Migrate manifests to networking.k8s.io/v1

### DIFF
--- a/argo-rollouts-demo/canary/canary-ingress.yaml
+++ b/argo-rollouts-demo/canary/canary-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: canary-demo
@@ -12,5 +12,8 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: canary-demo
-          servicePort: 80
+          service:
+            name: canary-demo
+            port:
+              number: 80
+        pathType: Prefix

--- a/argo-rollouts-demo/canary/canary-preview-ingress.yaml
+++ b/argo-rollouts-demo/canary/canary-preview-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: canary-demo-preview
@@ -12,5 +12,8 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: canary-demo-preview
-          servicePort: 80
+          service:
+            name: canary-demo-preview
+            port:
+              number: 80
+        pathType: Prefix


### PR DESCRIPTION
The `networking.k8s.io/v1beta1` API versions of Ingress is no longer served as of `v1.22`. Migration notes [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122). Tested by applying the manifests and noting that no more migration errors exist. 

