### PR TITLE
[argo-rollouts-demo] Update `px-metrics.yaml` to work with latest image.

### DIFF
--- a/argo-rollouts-demo/README.md
+++ b/argo-rollouts-demo/README.md
@@ -44,7 +44,9 @@ kubectl create namespace px-metrics
 kubectl -n px-metrics create secret generic px-credentials --from-literal=px-api-key=<YOUR API KEY VALUE HERE> --from-literal=px-cluster-id=<YOUR CLUSTER ID VALUE HERE>
 ```
 
-3. Install the Pixie metrics server onto your cluster with:
+3. [Optional] If using self-hosted Pixie Cloud, update the `PX_CLOUD_ADDR` in `px-metrics.yaml`.
+
+4. Create the Pixie metrics provider in your Kubernetes cluster in the `px-metrics` namespace:
 
 ```
 kubectl apply -f px-metrics.yaml

--- a/argo-rollouts-demo/px-metrics.yaml
+++ b/argo-rollouts-demo/px-metrics.yaml
@@ -20,6 +20,8 @@ spec:
         - name: app
           image: gcr.io/pixie-oss/pixie-dev/demo/argo-rollouts-demo:latest
           env:
+          - name: PX_CLOUD_ADDR
+            value: withpixie.ai:443
           - name: PX_CLUSTER_ID
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
The Pixie metrics provider pod gets stuck in `crashloopbackoff` without this environment variable. I think the `pxapi` client has changed since this demo was released to enforce providing the `cloudAddr` as a variable when creating a new client. 