### PR TITLE
fix: porting the code to ubuntu 24.04 with llvm 18 and libssl 3.0

### DIFF
--- a/openssl-tracer/Makefile
+++ b/openssl-tracer/Makefile
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 openssl_tracer: openssl_tracer.cc probe_deployment.cc
-	clang++ --std=c++17 -o $@ $^ -lbcc
+	clang++ --std=c++17 -o $@ $^ -lbcc -I /usr/lib/llvm-18 -I/usr/include/llvm-18
 
 clean:
 	rm openssl_tracer

--- a/openssl-tracer/README.md
+++ b/openssl-tracer/README.md
@@ -9,7 +9,7 @@ This demo was created to accompany the "Debugging with eBPF Part 3: Tracing SSL/
 You must have the BCC development package installed. On Ubuntu, the package can be installed as follows:
 
 ```
-sudo apt install libbpfcc-dev
+sudo apt install libbpfcc-dev binutils clang llvm bcc python3 openssl -y
 ```
 
 Other distributions have similar commands.
@@ -29,34 +29,26 @@ A demo application to trace is included. It is a simple client-server written in
 First, you'll have to generate some certificates for the client and server.
 To keep things simple, you can generate some self-signed certificates as follows:
 
-```
-make -C ssl_client_server certs
-```
 
-To run the demo app, you'll need two terminals.
+To run the demo, you'll need two terminals.
 
-In one terminal, run the server:
+In one terminal, open a secure connection to e.g. google
 
 ```
-cd ssl_client_server; ./server.py
+openssl s_client -connect google.com:443
 ```
 
-In the second terminal, run the client:
+In the second terminal, run the tracer on the ProcessID (pid) of the above connection
 
 ```
-cd ssl_client_server; ./client.py
+sudo ./openssl_tracer $(pgrep -f openssl)
+```
+Now, back in the openssl terminal
+```
+GET / HTTP/1.1
+and press enter twice
 ```
 
-## Run Tracer
 
-The BPF tracer is run as follows:
 
-```
-sudo ./openssl_tracer <pid>
-```
 
-To run it on the demo app, run the following command in a separate terminal:
-
-```
-sudo ./openssl_tracer $(pgrep -f "./client.py")
-```

--- a/openssl-tracer/openssl_tracer.cc
+++ b/openssl-tracer/openssl_tracer.cc
@@ -22,13 +22,14 @@
 #include <iostream>
 #include <streambuf>
 #include <string>
+#include <stdint.h> 
 
 #include "openssl_tracer_types.h"
 #include "probe_deployment.h"
 
 // A probe on entry of SSL_write
 UProbeSpec kSSLWriteEntryProbeSpec{
-    .obj_path = "/usr/lib/x86_64-linux-gnu/libssl.so.1.1",
+    .obj_path = "/usr/lib/x86_64-linux-gnu/libssl.so.3",
     .symbol = "SSL_write",
     .attach_type = BPF_PROBE_ENTRY,
     .probe_fn = "probe_entry_SSL_write",
@@ -36,7 +37,7 @@ UProbeSpec kSSLWriteEntryProbeSpec{
 
 // A probe on return of SSL_write
 UProbeSpec kSSLWriteRetProbeSpec{
-    .obj_path = "/usr/lib/x86_64-linux-gnu/libssl.so.1.1",
+    .obj_path = "/usr/lib/x86_64-linux-gnu/libssl.so.3",
     .symbol = "SSL_write",
     .attach_type = BPF_PROBE_RETURN,
     .probe_fn = "probe_ret_SSL_write",
@@ -44,7 +45,7 @@ UProbeSpec kSSLWriteRetProbeSpec{
 
 // A probe on entry of SSL_read
 UProbeSpec kSSLReadEntryProbeSpec{
-    .obj_path = "/usr/lib/x86_64-linux-gnu/libssl.so.1.1",
+    .obj_path = "/usr/lib/x86_64-linux-gnu/libssl.so.3",
     .symbol = "SSL_read",
     .attach_type = BPF_PROBE_ENTRY,
     .probe_fn = "probe_entry_SSL_read",
@@ -52,7 +53,7 @@ UProbeSpec kSSLReadEntryProbeSpec{
 
 // A probe on return of SSL_read
 UProbeSpec kSSLReadRetProbeSpec{
-    .obj_path = "/usr/lib/x86_64-linux-gnu/libssl.so.1.1",
+    .obj_path = "/usr/lib/x86_64-linux-gnu/libssl.so.3",
     .symbol = "SSL_read",
     .attach_type = BPF_PROBE_RETURN,
     .probe_fn = "probe_ret_SSL_read",


### PR DESCRIPTION
Summary: fix: porting the code to ubuntu 24.04 with llvm 18 and libssl 3.0

Changes: updated the version of the libssl and in the Readme reflected the install commands and replaced the demo app

Testing done: works on this live lab https://labs.iximiuz.com/courses/pixie-iot-4bd13e08/module-1/setup-pixie#pixie-k3s-intro 